### PR TITLE
Migrate to Media3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ ext {
     compileSdkVersion = 33
     minSdkVersion = 19
     targetSdkVersion = 31
+    coreVersion = '1.10.1'
     appcompatVersion = '1.6.1'
     materialVersion = '1.9.0'
     constraintLayoutVersion = '2.1.4'

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,12 @@ ext {
     compileSdkVersion = 33
     minSdkVersion = 19
     targetSdkVersion = 31
-    appcompatVersion = '1.5.1'
-    materialVersion = '1.1.0'
+    appcompatVersion = '1.6.1'
+    materialVersion = '1.9.0'
     constraintLayoutVersion = '2.1.4'
-    exoPlayerVersion = '2.18.1'
     glideVersion = '4.14.2'
+    media3Version = '1.1.1'
+    annotationVersion = '1.3.0'
 }
 
 task clean(type: Delete) {

--- a/previewseekbar-exoplayer/build.gradle
+++ b/previewseekbar-exoplayer/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply from: rootProject.file('gradle/publish.gradle')
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -14,9 +14,12 @@ android {
             withJavadocJar()
         }
     }
+    namespace 'com.github.rubensousa.previewseekbar.exoplayer'
 }
 
 dependencies {
     api project(':previewseekbar')
-    implementation "com.google.android.exoplayer:exoplayer-ui:$exoPlayerVersion"
+    implementation "androidx.media3:media3-exoplayer:$media3Version"
+    implementation "androidx.media3:media3-ui:$media3Version"
+    implementation "androidx.annotation:annotation:$annotationVersion"
 }

--- a/previewseekbar-exoplayer/build.gradle
+++ b/previewseekbar-exoplayer/build.gradle
@@ -19,6 +19,7 @@ android {
 
 dependencies {
     api project(':previewseekbar')
+    implementation "androidx.core:core:$coreVersion"
     implementation "androidx.media3:media3-exoplayer:$media3Version"
     implementation "androidx.media3:media3-ui:$media3Version"
     implementation "androidx.annotation:annotation:$annotationVersion"

--- a/previewseekbar-exoplayer/src/main/java/com/github/rubensousa/previewseekbar/exoplayer/PreviewTimeBar.java
+++ b/previewseekbar-exoplayer/src/main/java/com/github/rubensousa/previewseekbar/exoplayer/PreviewTimeBar.java
@@ -25,22 +25,24 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
+import androidx.annotation.OptIn;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.ui.DefaultTimeBar;
+import androidx.media3.ui.TimeBar;
 
 import com.github.rubensousa.previewseekbar.PreviewBar;
 import com.github.rubensousa.previewseekbar.PreviewDelegate;
 import com.github.rubensousa.previewseekbar.PreviewLoader;
 import com.github.rubensousa.previewseekbar.PreviewSeekBar;
 import com.github.rubensousa.previewseekbar.animator.PreviewAnimator;
-import com.google.android.exoplayer2.ui.DefaultTimeBar;
-import com.google.android.exoplayer2.ui.TimeBar;
 
 /**
  * A {@link DefaultTimeBar} that mimics the behavior of a {@link PreviewSeekBar}.
  * <p>
  * When the user scrubs this TimeBar, a preview will appear above the scrubber.
  */
+
+@OptIn(markerClass = UnstableApi.class)
 public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
 
     private PreviewDelegate delegate;
@@ -53,26 +55,26 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
     public PreviewTimeBar(Context context, AttributeSet attrs) {
         super(context, attrs);
         TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs,
-                com.google.android.exoplayer2.ui.R.styleable.DefaultTimeBar, 0, 0);
+                androidx.media3.ui.R.styleable.DefaultTimeBar, 0, 0);
         scrubberColor = typedArray.getInt(
-                com.google.android.exoplayer2.ui.R.styleable.DefaultTimeBar_scrubber_color,
+                androidx.media3.ui.R.styleable.DefaultTimeBar_scrubber_color,
                 DEFAULT_SCRUBBER_COLOR);
 
         final Drawable scrubberDrawable = typedArray.getDrawable(
-                com.google.android.exoplayer2.ui.R.styleable.DefaultTimeBar_scrubber_drawable);
+                androidx.media3.ui.R.styleable.DefaultTimeBar_scrubber_drawable);
 
         final int scrubberEnabledSize = typedArray.getDimensionPixelSize(
-                com.google.android.exoplayer2.ui.R.styleable.DefaultTimeBar_scrubber_enabled_size,
+                androidx.media3.ui.R.styleable.DefaultTimeBar_scrubber_enabled_size,
                 dpToPx(context.getResources().getDisplayMetrics(),
                         DEFAULT_SCRUBBER_ENABLED_SIZE_DP));
 
         final int scrubberDisabledSize = typedArray.getDimensionPixelSize(
-                com.google.android.exoplayer2.ui.R.styleable.DefaultTimeBar_scrubber_disabled_size,
+                androidx.media3.ui.R.styleable.DefaultTimeBar_scrubber_disabled_size,
                 dpToPx(context.getResources().getDisplayMetrics(),
                         DEFAULT_SCRUBBER_DISABLED_SIZE_DP));
 
         final int scrubberDraggedSize = typedArray.getDimensionPixelSize(
-                com.google.android.exoplayer2.ui.R.styleable.DefaultTimeBar_scrubber_dragged_size,
+                androidx.media3.ui.R.styleable.DefaultTimeBar_scrubber_dragged_size,
                 dpToPx(context.getResources().getDisplayMetrics(),
                         DEFAULT_SCRUBBER_DRAGGED_SIZE_DP));
 
@@ -127,7 +129,7 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
 
     @Override
     public void setPreviewThumbTintResource(int colorResource) {
-        setPreviewThumbTint(ContextCompat.getColor(getContext(), colorResource));
+        setPreviewThumbTint(getContext().getColor(colorResource));
     }
 
     @Override
@@ -136,7 +138,7 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
     }
 
     @Override
-    public void attachPreviewView(@NonNull FrameLayout previewView) {
+    public void attachPreviewView(FrameLayout previewView) {
         delegate.attachPreviewView(previewView);
     }
 
@@ -237,7 +239,7 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
     }
 
     @Override
-    public void setPreviewAnimator(@NonNull PreviewAnimator animator) {
+    public void setPreviewAnimator(PreviewAnimator animator) {
         delegate.setAnimator(animator);
     }
 

--- a/previewseekbar-exoplayer/src/main/java/com/github/rubensousa/previewseekbar/exoplayer/PreviewTimeBar.java
+++ b/previewseekbar-exoplayer/src/main/java/com/github/rubensousa/previewseekbar/exoplayer/PreviewTimeBar.java
@@ -25,7 +25,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.OptIn;
+import androidx.core.content.ContextCompat;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.ui.DefaultTimeBar;
 import androidx.media3.ui.TimeBar;
@@ -129,7 +131,7 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
 
     @Override
     public void setPreviewThumbTintResource(int colorResource) {
-        setPreviewThumbTint(getContext().getColor(colorResource));
+        setPreviewThumbTint(ContextCompat.getColor(getContext(), colorResource));
     }
 
     @Override
@@ -138,7 +140,7 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
     }
 
     @Override
-    public void attachPreviewView(FrameLayout previewView) {
+    public void attachPreviewView(@NonNull FrameLayout previewView) {
         delegate.attachPreviewView(previewView);
     }
 
@@ -239,7 +241,7 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
     }
 
     @Override
-    public void setPreviewAnimator(PreviewAnimator animator) {
+    public void setPreviewAnimator(@NonNull PreviewAnimator animator) {
         delegate.setAnimator(animator);
     }
 
@@ -258,19 +260,19 @@ public class PreviewTimeBar extends DefaultTimeBar implements PreviewBar {
     private class TimeBarDefaultOnScrubListener implements TimeBar.OnScrubListener {
 
         @Override
-        public void onScrubStart(TimeBar timeBar, long position) {
+        public void onScrubStart(@NonNull TimeBar timeBar, long position) {
             scrubProgress = (int) position;
             delegate.onScrubStart();
         }
 
         @Override
-        public void onScrubMove(TimeBar timeBar, long position) {
+        public void onScrubMove(@NonNull TimeBar timeBar, long position) {
             scrubProgress = (int) position;
             delegate.onScrubMove((int) position, true);
         }
 
         @Override
-        public void onScrubStop(TimeBar timeBar, long position, boolean canceled) {
+        public void onScrubStop(@NonNull TimeBar timeBar, long position, boolean canceled) {
             scrubProgress = (int) position;
             delegate.onScrubStop();
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -26,8 +26,10 @@ android {
 
 dependencies {
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation "androidx.annotation:annotation:$annotationVersion"
     implementation "com.google.android.material:material:$materialVersion"
-    implementation "com.google.android.exoplayer:exoplayer:$exoPlayerVersion"
+    implementation "androidx.media3:media3-ui:$media3Version"
+    implementation "androidx.media3:media3-exoplayer:$media3Version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     implementation project(':previewseekbar')

--- a/sample/src/main/java/com/github/rubensousa/previewseekbar/sample/MainActivity.java
+++ b/sample/src/main/java/com/github/rubensousa/previewseekbar/sample/MainActivity.java
@@ -24,8 +24,11 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.RadioGroup;
 
+import androidx.annotation.OptIn;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.ui.PlayerView;
 
 import com.github.rubensousa.previewseekbar.PreviewBar;
 import com.github.rubensousa.previewseekbar.PreviewSeekBar;
@@ -33,7 +36,6 @@ import com.github.rubensousa.previewseekbar.animator.PreviewFadeAnimator;
 import com.github.rubensousa.previewseekbar.animator.PreviewMorphAnimator;
 import com.github.rubensousa.previewseekbar.exoplayer.PreviewTimeBar;
 import com.github.rubensousa.previewseekbar.sample.exoplayer.ExoPlayerManager;
-import com.google.android.exoplayer2.ui.StyledPlayerView;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -46,7 +48,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        StyledPlayerView playerView = findViewById(R.id.player_view);
+        PlayerView playerView = findViewById(R.id.player_view);
         previewTimeBar = playerView.findViewById(R.id.exo_progress);
         previewSeekBar = findViewById(R.id.previewSeekBar);
 
@@ -110,6 +112,7 @@ public class MainActivity extends AppCompatActivity {
         exoPlayerManager.onStop();
     }
 
+    @OptIn(markerClass = UnstableApi.class)
     private void setupOptions() {
         // Enable or disable the previews
         SwitchCompat previewSwitch = findViewById(R.id.previewEnabledSwitch);

--- a/sample/src/main/java/com/github/rubensousa/previewseekbar/sample/exoplayer/ExoPlayerManager.java
+++ b/sample/src/main/java/com/github/rubensousa/previewseekbar/sample/exoplayer/ExoPlayerManager.java
@@ -20,6 +20,14 @@ package com.github.rubensousa.previewseekbar.sample.exoplayer;
 import android.net.Uri;
 import android.widget.ImageView;
 
+import androidx.annotation.OptIn;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.Player;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.ui.PlayerView;
+
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.Target;
 import com.github.rubensousa.previewseekbar.PreviewBar;
@@ -27,18 +35,13 @@ import com.github.rubensousa.previewseekbar.PreviewLoader;
 import com.github.rubensousa.previewseekbar.exoplayer.PreviewTimeBar;
 import com.github.rubensousa.previewseekbar.sample.R;
 import com.github.rubensousa.previewseekbar.sample.glide.GlideThumbnailTransformation;
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.ui.StyledPlayerView;
-import com.google.android.exoplayer2.util.Util;
 
-
+@OptIn(markerClass = UnstableApi.class)
 public class ExoPlayerManager implements PreviewLoader, PreviewBar.OnScrubListener {
 
     private static final String VIDEO_PATH = "asset:///video.mp4";
 
-    private StyledPlayerView playerView;
+    private PlayerView playerView;
     private ExoPlayer player;
     private PreviewTimeBar previewTimeBar;
     private ImageView imageView;
@@ -52,7 +55,7 @@ public class ExoPlayerManager implements PreviewLoader, PreviewBar.OnScrubListen
         }
     };
 
-    public ExoPlayerManager(StyledPlayerView playerView,
+    public ExoPlayerManager(PlayerView playerView,
                             PreviewTimeBar previewTimeBar,
                             ImageView imageView) {
         this.playerView = playerView;

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -36,7 +36,7 @@
             android:text="@string/preview_timebar"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.exoplayer2.ui.StyledPlayerView
+        <androidx.media3.ui.PlayerView
             android:id="@+id/player_view"
             android:layout_width="match_parent"
             android:layout_height="0dp"


### PR DESCRIPTION
This PR migrates the project to Media3.

Most of the code worked by simply replacing the ExoPlayer imports with Media3 ones.
ExoPlayer's StyledPlayerView corresponds to Media3's PlayerView.